### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -5,7 +5,7 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
@@ -84,7 +84,8 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
+def get_activities(response: Response):
+    response.headers["Cache-Control"] = "no-store"
     return activities
 
 
@@ -104,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not registered for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for interscholastic play",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Soccer Club": {
+        "description": "Soccer matches and friendly competitions",
+        "schedule": "Tuesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["alex@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, and mixed media techniques",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Theater production and performing arts",
+        "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["grace@mergington.edu", "ryan@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Explore physics, chemistry, and biology experiments",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 15,
+        "participants": ["noah@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Competitive debating and public speaking skills",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["ava@mergington.edu", "ethan@mergington.edu"]
     }
 }
 
@@ -62,6 +98,9 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    #Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,14 +4,25 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function showMessage(type, text) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +30,38 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participants = Array.isArray(details.participants) ? details.participants : [];
+        const participantsListHtml = participants.length
+          ? participants
+              .map(
+                (participant) => `
+                  <li class="participant-item">
+                    <span class="participant-email">${participant}</span>
+                    <button
+                      type="button"
+                      class="remove-participant-btn"
+                      data-activity="${name}"
+                      data-email="${participant}"
+                      aria-label="Unregister ${participant} from ${name}"
+                      title="Unregister participant"
+                    >✕</button>
+                  </li>
+                `
+              )
+              .join("")
+          : "<li class=\"participant-empty\">No participants yet</li>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p><strong>Participants (${participants.length}):</strong></p>
+            <ul class="participants-list">
+              ${participantsListHtml}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -59,25 +96,44 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage("success", result.message);
         signupForm.reset();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage("error", result.detail || "An error occurred");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("error", "Failed to sign up. Please try again.");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".remove-participant-btn");
+    if (!removeButton) {
+      return;
+    }
+
+    const activity = removeButton.dataset.activity;
+    const email = removeButton.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage("success", result.message);
+        await fetchActivities();
+      } else {
+        showMessage("error", result.detail || "Failed to unregister participant");
+      }
+    } catch (error) {
+      showMessage("error", "Failed to unregister participant. Please try again.");
+      console.error("Error unregistering participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,69 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #e0e7ff;
+  border-radius: 5px;
+  background-color: #f4f7ff;
+}
+
+.participants-section p {
+  margin-bottom: 8px;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #1a237e;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
+  background-color: #ffffff;
+  border: 1px solid #dde5ff;
+  border-radius: 4px;
+}
+
+.participant-item:last-child {
+  margin-bottom: 0;
+}
+
+.participant-email {
+  word-break: break-word;
+  font-size: 14px;
+}
+
+.remove-participant-btn {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background-color: #ffebee;
+  color: #c62828;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 1;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.remove-participant-btn:hover {
+  background-color: #ffcdd2;
+}
+
+.participant-empty {
+  color: #5c6a9e;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_state = deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(deepcopy(original_state))

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,47 @@
+def test_root_redirects_to_static_index(client):
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code in (307, 302)
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_all_seeded_activities(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload, dict)
+    assert len(payload) == 9
+    assert "Chess Club" in payload
+
+
+def test_get_activities_includes_expected_fields_for_each_activity(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    for details in payload.values():
+        assert "description" in details
+        assert "schedule" in details
+        assert "max_participants" in details
+        assert "participants" in details
+        assert isinstance(details["participants"], list)
+
+
+def test_get_activities_sets_no_store_cache_header(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_get_activities_contains_seed_participants(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert "michael@mergington.edu" in payload["Chess Club"]["participants"]
+    assert "daniel@mergington.edu" in payload["Chess Club"]["participants"]

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,27 +1,40 @@
 def test_root_redirects_to_static_index(client):
-    response = client.get("/", follow_redirects=False)
+    # Arrange
+    endpoint = "/"
 
+    # Act
+    response = client.get(endpoint, follow_redirects=False)
+
+    # Assert
     assert response.status_code in (307, 302)
     assert response.headers["location"] == "/static/index.html"
 
 
 def test_get_activities_returns_all_seeded_activities(client):
-    response = client.get("/activities")
+    # Arrange
+    endpoint = "/activities"
 
-    assert response.status_code == 200
+    # Act
+    response = client.get(endpoint)
     payload = response.json()
 
+    # Assert
+    assert response.status_code == 200
     assert isinstance(payload, dict)
     assert len(payload) == 9
     assert "Chess Club" in payload
 
 
 def test_get_activities_includes_expected_fields_for_each_activity(client):
-    response = client.get("/activities")
+    # Arrange
+    endpoint = "/activities"
 
-    assert response.status_code == 200
+    # Act
+    response = client.get(endpoint)
     payload = response.json()
 
+    # Assert
+    assert response.status_code == 200
     for details in payload.values():
         assert "description" in details
         assert "schedule" in details
@@ -31,17 +44,26 @@ def test_get_activities_includes_expected_fields_for_each_activity(client):
 
 
 def test_get_activities_sets_no_store_cache_header(client):
-    response = client.get("/activities")
+    # Arrange
+    endpoint = "/activities"
 
+    # Act
+    response = client.get(endpoint)
+
+    # Assert
     assert response.status_code == 200
     assert response.headers["cache-control"] == "no-store"
 
 
 def test_get_activities_contains_seed_participants(client):
-    response = client.get("/activities")
+    # Arrange
+    endpoint = "/activities"
 
-    assert response.status_code == 200
+    # Act
+    response = client.get(endpoint)
     payload = response.json()
 
+    # Assert
+    assert response.status_code == 200
     assert "michael@mergington.edu" in payload["Chess Club"]["participants"]
     assert "daniel@mergington.edu" in payload["Chess Club"]["participants"]

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,47 @@
+def test_signup_adds_new_participant(client):
+    response = client.post(
+        "/activities/Chess%20Club/signup",
+        params={"email": "newstudent@mergington.edu"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Signed up newstudent@mergington.edu for Chess Club"
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()["Chess Club"]["participants"]
+    assert "newstudent@mergington.edu" in participants
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    response = client.post(
+        "/activities/Unknown%20Club/signup",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_signup_returns_400_for_duplicate_registration(client):
+    response = client.post(
+        "/activities/Chess%20Club/signup",
+        params={"email": "michael@mergington.edu"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_increases_participant_count_by_one(client):
+    before = client.get("/activities").json()["Programming Class"]["participants"]
+    before_count = len(before)
+
+    response = client.post(
+        "/activities/Programming%20Class/signup",
+        params={"email": "countcheck@mergington.edu"},
+    )
+
+    after = client.get("/activities").json()["Programming Class"]["participants"]
+
+    assert response.status_code == 200
+    assert len(after) == before_count + 1

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,47 +1,56 @@
 def test_signup_adds_new_participant(client):
-    response = client.post(
-        "/activities/Chess%20Club/signup",
-        params={"email": "newstudent@mergington.edu"},
-    )
+    # Arrange
+    endpoint = "/activities/Chess%20Club/signup"
+    email = "newstudent@mergington.edu"
 
-    assert response.status_code == 200
-    assert response.json()["message"] == "Signed up newstudent@mergington.edu for Chess Club"
-
+    # Act
+    response = client.post(endpoint, params={"email": email})
     activities_response = client.get("/activities")
     participants = activities_response.json()["Chess Club"]["participants"]
-    assert "newstudent@mergington.edu" in participants
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == "Signed up newstudent@mergington.edu for Chess Club"
+    assert email in participants
 
 
 def test_signup_returns_404_for_unknown_activity(client):
-    response = client.post(
-        "/activities/Unknown%20Club/signup",
-        params={"email": "student@mergington.edu"},
-    )
+    # Arrange
+    endpoint = "/activities/Unknown%20Club/signup"
+    email = "student@mergington.edu"
 
+    # Act
+    response = client.post(endpoint, params={"email": email})
+
+    # Assert
     assert response.status_code == 404
     assert response.json()["detail"] == "Activity not found"
 
 
 def test_signup_returns_400_for_duplicate_registration(client):
-    response = client.post(
-        "/activities/Chess%20Club/signup",
-        params={"email": "michael@mergington.edu"},
-    )
+    # Arrange
+    endpoint = "/activities/Chess%20Club/signup"
+    email = "michael@mergington.edu"
 
+    # Act
+    response = client.post(endpoint, params={"email": email})
+
+    # Assert
     assert response.status_code == 400
     assert response.json()["detail"] == "Student already signed up for this activity"
 
 
 def test_signup_increases_participant_count_by_one(client):
+    # Arrange
     before = client.get("/activities").json()["Programming Class"]["participants"]
     before_count = len(before)
+    endpoint = "/activities/Programming%20Class/signup"
+    email = "countcheck@mergington.edu"
 
-    response = client.post(
-        "/activities/Programming%20Class/signup",
-        params={"email": "countcheck@mergington.edu"},
-    )
-
+    # Act
+    response = client.post(endpoint, params={"email": email})
     after = client.get("/activities").json()["Programming Class"]["participants"]
 
+    # Assert
     assert response.status_code == 200
     assert len(after) == before_count + 1

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,47 @@
+def test_unregister_removes_existing_participant(client):
+    response = client.delete(
+        "/activities/Chess%20Club/participants",
+        params={"email": "michael@mergington.edu"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Unregistered michael@mergington.edu from Chess Club"
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()["Chess Club"]["participants"]
+    assert "michael@mergington.edu" not in participants
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    response = client.delete(
+        "/activities/Unknown%20Club/participants",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_for_non_registered_participant(client):
+    response = client.delete(
+        "/activities/Chess%20Club/participants",
+        params={"email": "notregistered@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not registered for this activity"
+
+
+def test_unregister_decreases_participant_count_by_one(client):
+    before = client.get("/activities").json()["Soccer Club"]["participants"]
+    before_count = len(before)
+
+    response = client.delete(
+        "/activities/Soccer%20Club/participants",
+        params={"email": "alex@mergington.edu"},
+    )
+
+    after = client.get("/activities").json()["Soccer Club"]["participants"]
+
+    assert response.status_code == 200
+    assert len(after) == before_count - 1

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,47 +1,56 @@
 def test_unregister_removes_existing_participant(client):
-    response = client.delete(
-        "/activities/Chess%20Club/participants",
-        params={"email": "michael@mergington.edu"},
-    )
+    # Arrange
+    endpoint = "/activities/Chess%20Club/participants"
+    email = "michael@mergington.edu"
 
-    assert response.status_code == 200
-    assert response.json()["message"] == "Unregistered michael@mergington.edu from Chess Club"
-
+    # Act
+    response = client.delete(endpoint, params={"email": email})
     activities_response = client.get("/activities")
     participants = activities_response.json()["Chess Club"]["participants"]
-    assert "michael@mergington.edu" not in participants
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == "Unregistered michael@mergington.edu from Chess Club"
+    assert email not in participants
 
 
 def test_unregister_returns_404_for_unknown_activity(client):
-    response = client.delete(
-        "/activities/Unknown%20Club/participants",
-        params={"email": "student@mergington.edu"},
-    )
+    # Arrange
+    endpoint = "/activities/Unknown%20Club/participants"
+    email = "student@mergington.edu"
 
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+
+    # Assert
     assert response.status_code == 404
     assert response.json()["detail"] == "Activity not found"
 
 
 def test_unregister_returns_404_for_non_registered_participant(client):
-    response = client.delete(
-        "/activities/Chess%20Club/participants",
-        params={"email": "notregistered@mergington.edu"},
-    )
+    # Arrange
+    endpoint = "/activities/Chess%20Club/participants"
+    email = "notregistered@mergington.edu"
 
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+
+    # Assert
     assert response.status_code == 404
     assert response.json()["detail"] == "Student is not registered for this activity"
 
 
 def test_unregister_decreases_participant_count_by_one(client):
+    # Arrange
     before = client.get("/activities").json()["Soccer Club"]["participants"]
     before_count = len(before)
+    endpoint = "/activities/Soccer%20Club/participants"
+    email = "alex@mergington.edu"
 
-    response = client.delete(
-        "/activities/Soccer%20Club/participants",
-        params={"email": "alex@mergington.edu"},
-    )
-
+    # Act
+    response = client.delete(endpoint, params={"email": email})
     after = client.get("/activities").json()["Soccer Club"]["participants"]
 
+    # Assert
     assert response.status_code == 200
     assert len(after) == before_count - 1


### PR DESCRIPTION
This pull request adds participant management features to the extracurricular activities app, enabling students to unregister from activities and improving both backend and frontend handling of participants. It also introduces comprehensive automated tests for signup and unregister functionality, and enhances the UI to display and manage participants interactively.

**Backend enhancements:**

* Added a new API endpoint (`DELETE /activities/{activity_name}/participants`) to allow unregistering a student from an activity, with appropriate error handling for unknown activities and non-registered students.
* Modified the signup endpoint to prevent duplicate registrations for the same student in an activity.
* Expanded the initial activities data with more clubs and seeded participants.
* Added a `Cache-Control: no-store` header to the `/activities` endpoint response to prevent caching of activity data. [[1]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L51-R88) [[2]](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00L8-R8)

**Frontend improvements:**

* Updated the UI to display participants for each activity, including a button to remove (unregister) a participant, and improved user feedback with a message display system. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R64) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R136)
* Enhanced styling for the participants section and remove button for better usability and clarity.

**Testing and reliability:**

* Added fixtures to reset application state between tests for isolation and repeatability.
* Implemented thorough backend tests for root redirects, activity listing, signup (including edge cases), and unregister endpoints, ensuring correct API behavior and error handling. [[1]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R69) [[2]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R56) [[3]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R56)